### PR TITLE
fix: load image from cache sync

### DIFF
--- a/Source/Components/ImageView/ImageView.swift
+++ b/Source/Components/ImageView/ImageView.swift
@@ -23,55 +23,19 @@ class ImageView: UIImageView {
 
     // MARK: Methods
 
-    func setImage(from urlString: String,
-                  with placeholder: UIImage? = nil,
-                  using imageCache: ImageCache? = nil) {
-        imageTask?.cancel()
-        imageTask = Task {
-            try await setImageAsync(from: urlString, with: placeholder, using: imageCache)
-        }
-    }
-
     func setImage(from url: URL,
                   with placeholder: UIImage? = nil,
                   using imageCache: ImageCache? = nil) {
         imageTask?.cancel()
-        imageTask = Task {
-            try await setImageAsync(from: url, with: placeholder, using: imageCache)
-        }
-    }
-
-    func setRemoteImage(from url: URL, saveTo imageCache: ImageCache? = nil) {
-        imageTask?.cancel()
-        imageTask = Task {
-            try await setRemoteImageAsync(from: url, saveTo: imageCache)
-        }
-    }
-}
-
-// MARK: - Helpers
-
-extension ImageView {
-    private func setImageAsync(from urlString: String,
-                               with placeholder: UIImage? = nil,
-                               using imageCache: ImageCache? = nil) async throws {
-        guard let url = URL(string: urlString) else {
-            throw ImageDownloadError.badURL
-        }
-        try await setImageAsync(from: url, with: placeholder, using: imageCache)
-    }
-
-    private func setImageAsync(from url: URL,
-                               with placeholder: UIImage? = nil,
-                               using imageCache: ImageCache? = nil) async throws {
         setImage(placeholder)
         let imageCache = imageCache ?? defaultImageCache
         if let cachedImage = imageCache.getImage(forKey: url) {
-            try Task.checkCancellation()
             setImage(cachedImage)
             return
         }
-        try await setRemoteImageAsync(from: url, saveTo: imageCache)
+        imageTask = Task {
+            try await setRemoteImageAsync(from: url, saveTo: imageCache)
+        }
     }
 
     private func setRemoteImageAsync(from url: URL, saveTo imageCache: ImageCache? = nil) async throws {


### PR DESCRIPTION
My improvised image cache loaded images from cache asynchronously which enabled the transition to start before the destination image was loaded. (#2)

I suggest using an image cache like Nuke in production.