### PR TITLE
fix: handle rapid swipe gesture edge case

### DIFF
--- a/Source/Transition/SharedTransitionInteractionController.swift
+++ b/Source/Transition/SharedTransitionInteractionController.swift
@@ -25,6 +25,8 @@ class SharedTransitionInteractionController: NSObject {
 
     // MARK: Private properties
 
+    private var alreadyFinished = false
+    private var alreadyCancelled = false
     private var config: SharedTransitionConfig = .interactive
     private var context: Context?
 }
@@ -32,6 +34,8 @@ class SharedTransitionInteractionController: NSObject {
 // MARK: - UIViewControllerInteractiveTransitioning
 
 extension SharedTransitionInteractionController: UIViewControllerInteractiveTransitioning {
+    var wantsInteractiveStart: Bool { false }
+
     func startInteractiveTransition(_ transitionContext: UIViewControllerContextTransitioning) {
         prepareViewController(from: transitionContext)
 
@@ -75,6 +79,14 @@ extension SharedTransitionInteractionController: UIViewControllerInteractiveTran
         fromView.mask = mask
         toView.addSubview(placeholder)
         toView.addSubview(overlay)
+
+        if alreadyFinished {
+            finish()
+        }
+
+        if alreadyCancelled {
+            cancel()
+        }
     }
 }
 
@@ -94,7 +106,10 @@ extension SharedTransitionInteractionController {
     }
 
     func cancel() {
-        guard let context else { return }
+        guard let context else {
+            alreadyCancelled = true
+            return
+        }
         context.transitionContext.cancelInteractiveTransition()
         let maskRadius = config.maskCornerRadius
         let overlayOpacity = config.overlayOpacity
@@ -112,7 +127,10 @@ extension SharedTransitionInteractionController {
     }
 
     func finish() {
-        guard let context else { return }
+        guard let context else {
+            alreadyFinished = true
+            return
+        }
         context.transitionContext.finishInteractiveTransition()
         let maskFrame = context.toFrame.aspectFit(to: context.fromFrame)
         UIView.animate(duration: config.duration, curve: config.curve) {


### PR DESCRIPTION
On really fast swipe back gestures, the detail screen can become 'stuck' and lose its navigation controller.

This is bacuse`startInteractiveTransition(_:)` can get called **after** the pan gesture recognizer called `begin` and `finish` in case of a rapid swipe gesture. In these edge cases, we need to finish (or cancel) the transition immediately.

Also, `wantsInteractiveStart` must be set to `false` otherwise UIKit will prevent our `finish` animation from happening as it will pause any animations by default inside `startInteractiveTransition ` if `wantsInteractiveStart ` is **true**.
